### PR TITLE
added /tmp

### DIFF
--- a/org.gnu.Emacs.json
+++ b/org.gnu.Emacs.json
@@ -9,7 +9,8 @@
         "--share=ipc",
         "--socket=pulseaudio",
         "--socket=x11",
-        "--filesystem=host"
+        "--filesystem=host",
+	"--filesystem=/tmp"
     ],
     "modules": [
         {

--- a/org.gnu.Emacs.json
+++ b/org.gnu.Emacs.json
@@ -10,7 +10,7 @@
         "--socket=pulseaudio",
         "--socket=x11",
         "--filesystem=host",
-	"--filesystem=/tmp"
+        "--filesystem=/tmp"
     ],
     "modules": [
         {


### PR DESCRIPTION
write access to /tmp is not working with --filesystem=host. Added /tmp
so that emacs' server and emacsclient will work correctly.